### PR TITLE
fix: restore Next.js build for Vercel

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -109,8 +109,9 @@ const getCollection = (id: string) => {
   return collections[id as keyof typeof collections] || null;
 };
 
-export default function CollectionDetailPage({ params }: { params: { id: string } }) {
-  const collection = getCollection(params.id);
+export default async function CollectionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const collection = getCollection(id);
 
   if (!collection) {
     return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,10 +53,10 @@
   * {
     @apply border-border;
   }
-  body {
-    @apply bg-background text-foreground;
-    font-family: var(--font-geist-sans);
-  }
+    body {
+      @apply bg-background text-foreground;
+      font-family: sans-serif;
+    }
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,10 @@
 import type { Metadata, Viewport } from "next";
-import { Inter } from "next/font/google";
+// Using system fonts during build to avoid network font fetching issues
 import "./globals.css";
 import ClientBody from "./ClientBody";
 import Script from "next/script";
 import Animations from './animations';
 
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: {
@@ -72,7 +67,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} scroll-smooth`}>
+      <html lang="en" className="scroll-smooth">
       <head>
         <Script
           crossOrigin="anonymous"

--- a/src/app/leathers/[id]/page.tsx
+++ b/src/app/leathers/[id]/page.tsx
@@ -82,8 +82,9 @@ const getLeatherProduct = (id: string) => {
   return products[id as keyof typeof products] || null;
 };
 
-export default function LeatherDetailPage({ params }: { params: { id: string } }) {
-  const product = getLeatherProduct(params.id);
+export default async function LeatherDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const product = getLeatherProduct(id);
 
   if (!product) {
     return (
@@ -232,7 +233,7 @@ export default function LeatherDetailPage({ params }: { params: { id: string } }
                 'sterling': getLeatherProduct('sterling'),
                 'opulent': getLeatherProduct('opulent'),
               } : {})
-                .filter(p => p.id !== params.id)
+                .filter(p => p.id !== id)
                 .slice(0, 3)
                 .map(relatedProduct => (
                 <Link


### PR DESCRIPTION
## Summary
- avoid Google font download during build by relying on system fonts
- update dynamic route pages to use async params compatible with Next.js 15

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28a42c10483258e9b96bc1833e78e