### PR TITLE
fix: improve hero sections for mobile viewport

### DIFF
--- a/src/app/about-grandtex/page.tsx
+++ b/src/app/about-grandtex/page.tsx
@@ -6,7 +6,7 @@ export default function AboutPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[60vh] bg-black text-white mt-20">
+      <section className="relative w-full min-h-[60vh] md:h-[60vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/1723594169.jpeg"

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -131,7 +131,7 @@ export default async function CollectionDetailPage({ params }: { params: Promise
     <MainLayout>
       <div className="mt-20">
         {/* Hero Section */}
-        <section className="relative w-full h-[60vh] bg-black text-white">
+        <section className="relative w-full min-h-[60vh] md:h-[60vh] bg-black text-white">
           <div className="absolute inset-0 z-0">
             <Image
               src={collection.mainImage}

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -45,7 +45,7 @@ export default function CollectionsPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+      <section className="relative w-full min-h-[40vh] md:h-[40vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/1829320189.jpeg"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export default function ContactPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+      <section className="relative w-full min-h-[40vh] md:h-[40vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/271436679.jpeg"

--- a/src/app/leathers/page.tsx
+++ b/src/app/leathers/page.tsx
@@ -64,7 +64,7 @@ export default function LeathersPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+        <section className="relative w-full min-h-[40vh] md:h-[40vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3442149313.jpeg"

--- a/src/app/sustainability/page.tsx
+++ b/src/app/sustainability/page.tsx
@@ -6,7 +6,7 @@ export default function SustainabilityPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[60vh] bg-black text-white mt-20">
+      <section className="relative w-full min-h-[60vh] md:h-[60vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/180971912.jpeg"

--- a/src/app/tanneries/page.tsx
+++ b/src/app/tanneries/page.tsx
@@ -43,7 +43,7 @@ export default function TanneriesPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[50vh] bg-black text-white mt-20">
+      <section className="relative w-full min-h-[50vh] md:h-[50vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3036160331.jpeg"

--- a/src/app/why-grandtex/page.tsx
+++ b/src/app/why-grandtex/page.tsx
@@ -39,7 +39,7 @@ export default function WhyGrandtexPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[50vh] bg-black text-white mt-20">
+        <section className="relative w-full min-h-[50vh] md:h-[50vh] bg-black text-white mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/2560085916.jpeg"


### PR DESCRIPTION
## Summary
- use `min-h-[40vh|50vh|60vh] md:h-[40vh|50vh|60vh]` for hero sections to prevent white bars on mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc31f7ec83259a8abf754d86ea96