### PR TITLE
Add cleanup for product hover effects

### DIFF
--- a/src/app/animations.tsx
+++ b/src/app/animations.tsx
@@ -1,7 +1,11 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { initScrollAnimations, initParallaxEffect, initProductHoverEffects } from '@/lib/animate';
+import { useEffect } from "react";
+import {
+  initScrollAnimations,
+  initParallaxEffect,
+  initProductHoverEffects,
+} from "@/lib/animate";
 
 export default function Animations() {
   useEffect(() => {
@@ -12,11 +16,12 @@ export default function Animations() {
     const cleanupParallax = initParallaxEffect();
 
     // Initialize product hover effects
-    initProductHoverEffects();
+    const cleanupProductHover = initProductHoverEffects();
 
     // Cleanup on unmount
     return () => {
       if (cleanupParallax) cleanupParallax();
+      if (cleanupProductHover) cleanupProductHover();
     };
   }, []);
 

--- a/src/lib/animate.ts
+++ b/src/lib/animate.ts
@@ -1,69 +1,85 @@
-'use client';
+"use client";
 
 export const initScrollAnimations = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const fadeElements = document.querySelectorAll('.animate-fade-in-scroll');
+  const fadeElements = document.querySelectorAll(".animate-fade-in-scroll");
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('animate-fade-in-up');
-        observer.unobserve(entry.target);
-      }
-    });
-  }, { threshold: 0.1 });
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("animate-fade-in-up");
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1 },
+  );
 
-  fadeElements.forEach(element => {
+  fadeElements.forEach((element) => {
     observer.observe(element);
   });
 };
 
 export const initParallaxEffect = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const parallaxElements = document.querySelectorAll('[data-parallax]');
+  const parallaxElements = document.querySelectorAll("[data-parallax]");
 
   const handleScroll = () => {
     const scrollTop = window.scrollY;
 
     parallaxElements.forEach((element) => {
-      const speed = Number(element.getAttribute('data-parallax-speed')) || 0.2;
+      const speed = Number(element.getAttribute("data-parallax-speed")) || 0.2;
       const offset = scrollTop * speed;
       (element as HTMLElement).style.transform = `translateY(${offset}px)`;
     });
   };
 
-  window.addEventListener('scroll', handleScroll);
+  window.addEventListener("scroll", handleScroll);
 
   // Cleanup function
   return () => {
-    window.removeEventListener('scroll', handleScroll);
+    window.removeEventListener("scroll", handleScroll);
   };
 };
 
 export const initProductHoverEffects = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const productCards = document.querySelectorAll('[data-product-card]');
+  const productCards = document.querySelectorAll("[data-product-card]");
+  const listeners: Array<() => void> = [];
 
-  productCards.forEach(card => {
-    card.addEventListener('mouseenter', () => {
-      card.classList.add('scale-[1.02]');
+  productCards.forEach((card) => {
+    const handleMouseEnter = () => {
+      card.classList.add("scale-[1.02]");
 
-      const image = card.querySelector('[data-product-image]');
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.add('scale-110');
+        image.classList.add("scale-110");
       }
-    });
+    };
 
-    card.addEventListener('mouseleave', () => {
-      card.classList.remove('scale-[1.02]');
+    const handleMouseLeave = () => {
+      card.classList.remove("scale-[1.02]");
 
-      const image = card.querySelector('[data-product-image]');
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.remove('scale-110');
+        image.classList.remove("scale-110");
       }
+    };
+
+    card.addEventListener("mouseenter", handleMouseEnter);
+    card.addEventListener("mouseleave", handleMouseLeave);
+
+    listeners.push(() => {
+      card.removeEventListener("mouseenter", handleMouseEnter);
+      card.removeEventListener("mouseleave", handleMouseLeave);
     });
   });
+
+  return () => {
+    listeners.forEach((cleanup) => cleanup());
+  };
 };


### PR DESCRIPTION
## Summary
- return a cleanup function from `initProductHoverEffects` to remove event listeners
- call the returned cleanup in `Animations` component on unmount

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c15f0fc083259dbee98adf17cb50