### PR TITLE
Enable Next.js image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   allowedDevOrigins: ["*.preview.same-app.com"],
   images: {
-    unoptimized: true,
+    unoptimized: false,
     domains: [
       "source.unsplash.com",
       "images.unsplash.com",


### PR DESCRIPTION
## Summary
- enable Next.js image optimization by disabling the `unoptimized` flag
- ensure external images from Unsplash and Same Assets domains remain explicitly whitelisted

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c15fcaa08325b38ad47bcc9ddf58