### PR TITLE
Use ESLint CLI for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
-    "lint": "bunx tsc --noEmit && next lint",
+    "lint": "bunx tsc --noEmit && eslint .",
     "format": "bunx biome format --write"
   },
   "dependencies": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,7 @@
 import type { Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
+import tailwindcssAnimate from "tailwindcss-animate";
+import type { PluginAPI } from "tailwindcss/types/config";
 
 export default {
     darkMode: ["class"],
@@ -119,8 +122,8 @@ export default {
     }
   },
   plugins: [
-    require("tailwindcss-animate"),
-    function({ addBase, addComponents }: any) {
+    tailwindcssAnimate,
+    plugin(({ addBase, addComponents }: PluginAPI) => {
       addBase({
         '.animate-fade-in-scroll': {
           opacity: '0',
@@ -157,6 +160,6 @@ export default {
           }
         });
       }
-    }
+    })
   ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- run ESLint directly via `eslint .` instead of `next lint`
- switch Tailwind config to ESM imports and type plugin callback so standard ESLint rules pass

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c158c3f08325ac75768e902d863b