### PR TITLE
chore: enable common lint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,12 +17,6 @@ const eslintConfig = [
         warnOnUnsupportedTypeScriptVersion: false,
       },
     },
-    rules: {
-      "@typescript-eslint/no-unused-vars": "off",
-      "react/no-unescaped-entities": "off",
-      "@next/next/no-img-element": "off",
-      "jsx-a11y/alt-text": "off",
-    },
   },
 ];
 

--- a/src/app/ClientBody.tsx
+++ b/src/app/ClientBody.tsx
@@ -14,6 +14,7 @@ export default function ClientBody({
     document.body.className = "antialiased font-inter bg-background";
     initScrollAnimations();
     const cleanupParallax = initParallaxEffect();
+    return cleanupParallax;
   }, []);
 
   return <div className="antialiased font-inter">{children}</div>;

--- a/src/app/why-grandtex/page.tsx
+++ b/src/app/why-grandtex/page.tsx
@@ -267,7 +267,7 @@ export default function WhyGrandtexPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <div className="bg-gray-800 p-8 rounded-lg">
-              <div className="text-2xl text-accent mb-4">"</div>
+              <div className="text-2xl text-accent mb-4">&quot;</div>
               <p className="text-lg mb-6">
                 GRANDTEX постоянно поставляет исключительную кожу,
                 соответствующую нашим строгим стандартам. Их техническая
@@ -283,7 +283,7 @@ export default function WhyGrandtexPage() {
             </div>
 
             <div className="bg-gray-800 p-8 rounded-lg">
-              <div className="text-2xl text-accent mb-4">"</div>
+              <div className="text-2xl text-accent mb-4">&quot;</div>
               <p className="text-lg mb-6">
                 Будучи бутиковым производителем, мы ценим готовность GRANDTEX
                 работать с небольшими объёмами заказов, сохраняя при этом такой

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,13 +3,12 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
 import { usePathname } from "next/navigation";
 import { Menu } from "lucide-react";
 
 export default function Header({ transparent = false }) {
   const [isScrolled, setIsScrolled] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
 
   useEffect(() => {
@@ -89,7 +88,6 @@ export default function Header({ transparent = false }) {
               <button
                 aria-label="Открыть меню"
                 className={`md:hidden flex items-center transition-colors duration-300 ${textClasses} hover:opacity-75`}
-                onClick={() => setIsMenuOpen(true)}
               >
                 <Menu className="h-6 w-6" />
               </button>
@@ -103,18 +101,15 @@ export default function Header({ transparent = false }) {
                   <Link href="/" className="text-3xl font-bold">
                     grandtex
                   </Link>
-                  <button
-                    className="text-gray-500 hover:text-black transition-colors"
-                    onClick={() => setIsMenuOpen(false)}
-                  >
+                  <SheetClose className="text-gray-500 hover:text-black transition-colors">
                     Закрыть
-                  </button>
+                  </SheetClose>
                 </div>
 
                 <div className="flex-1 overflow-auto px-8 py-10">
                   <nav className="space-y-12">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                      {navLinks.slice(0, 4).map((link, index) => (
+                      {navLinks.slice(0, 4).map((link) => (
                         <div key={link.title} className="space-y-4">
                           <Link
                             href={link.href}


### PR DESCRIPTION
## Summary
- stop globally disabling `no-unused-vars`, `no-img-element`, `react/no-unescaped-entities`, and `jsx-a11y/alt-text`
- return cleanup function in `ClientBody`
- replace raw quotes with entities in `why-grandtex` testimonials
- remove unused menu state and leverage `SheetClose`

## Testing
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b2c159b32c8325ace8716d67927be7