### PR TITLE
Consolidate animation setup and cleanup in ClientBody

### DIFF
--- a/src/app/ClientBody.tsx
+++ b/src/app/ClientBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { initScrollAnimations, initParallaxEffect, initProductHoverEffects } from '../lib/animate';
 
 export default function ClientBody({
@@ -9,20 +10,21 @@ export default function ClientBody({
   children: React.ReactNode;
 }) {
   // Remove any extension-added classes during hydration
+  const pathname = usePathname();
   useEffect(() => {
     // This runs only on the client after hydration
     document.body.className = "antialiased font-inter bg-background";
 
-    // Initialize animations and effects once on mount
+    // Initialize animations and effects when the route changes
     initScrollAnimations();
     const cleanupParallax = initParallaxEffect();
     initProductHoverEffects();
 
-    // Cleanup parallax effect on unmount
+    // Cleanup parallax effect on unmount or route change
     return () => {
       if (cleanupParallax) cleanupParallax();
     };
-  }, []);
+  }, [pathname]);
 
   return <div className="antialiased font-inter">{children}</div>;
 }


### PR DESCRIPTION
## Summary
- centralize animation initialization within `ClientBody`
- remove obsolete `Animations` component and usage
- clean up parallax effect on unmount
- re-run animation initializers after route changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c9a1ea6c8325b058659083cc96a0