### PR TITLE
Add canonical SEO links and placeholder pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://grandtex.ru/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://grandtex.ru/</loc>
+  </url>
+  <url>
+    <loc>https://grandtex.ru/services</loc>
+  </url>
+  <url>
+    <loc>https://grandtex.ru/production</loc>
+  </url>
+  <url>
+    <loc>https://grandtex.ru/portfolio</loc>
+  </url>
+  <url>
+    <loc>https://grandtex.ru/calculator</loc>
+  </url>
+  <url>
+    <loc>https://grandtex.ru/contact</loc>
+  </url>
+</urlset>

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function CalculatorPage() {
+  return (
+    <MainLayout>
+      <section className="pt-24 px-8">
+        <h1 className="text-3xl font-bold mb-4">Калькулятор стоимости</h1>
+        <p>Интерактивный калькулятор стоимости будет доступен здесь в ближайшее время.</p>
+      </section>
+    </MainLayout>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,9 @@ export const metadata: Metadata = {
     telephone: false,
   },
   metadataBase: new URL("https://grandtex.ru"),
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     title: "GRANDTEX - Производство одежды полного цикла",
     description:

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function PortfolioPage() {
+  return (
+    <MainLayout>
+      <section className="pt-24 px-8">
+        <h1 className="text-3xl font-bold mb-4">Портфолио</h1>
+        <p>В этом разделе будут представлены реализованные проекты компании.</p>
+      </section>
+    </MainLayout>
+  );
+}

--- a/src/app/production/page.tsx
+++ b/src/app/production/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function ProductionPage() {
+  return (
+    <MainLayout>
+      <section className="pt-24 px-8">
+        <h1 className="text-3xl font-bold mb-4">Производство</h1>
+        <p>Информация о производственных возможностях появится здесь позже.</p>
+      </section>
+    </MainLayout>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function ServicesPage() {
+  return (
+    <MainLayout>
+      <section className="pt-24 px-8">
+        <h1 className="text-3xl font-bold mb-4">Услуги</h1>
+        <p>Раздел находится в разработке. Здесь будет информация о наших услугах.</p>
+      </section>
+    </MainLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add canonical URL configuration to site metadata
- provide robots.txt and sitemap.xml
- stub out Services, Production, Portfolio and Calculator routes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf453cb883259a8ec692d0a05807